### PR TITLE
Buoyancy update + negative Markstein length

### DIFF
--- a/Functions/fct_decalage.m
+++ b/Functions/fct_decalage.m
@@ -26,7 +26,7 @@ if Lb>0
     end
 
 else
-    x=1:0.00005:6;
+    x=1:0.00005:10;
     t=real(2*(Lb/Vs)*expint((log(x.^2)))-2*(Lb/Vs)*(1./(x.^2.*log(x)))+decal);
     rf=-2*Lb./(x.*log(x));
     b=1;

--- a/Functions/fct_nonlineaire.m
+++ b/Functions/fct_nonlineaire.m
@@ -2,5 +2,3 @@ function erreur=fct_nonlineaire(Param,Rbrut,Vitpoly)
 CP1=Param(1);
 CP2=Param(2);
 erreur=sum(abs((Rbrut.*Vitpoly.*(log(Vitpoly/CP1))+2.*CP2.*CP1).^2));
-
-

--- a/Functions/fct_optirayon.m
+++ b/Functions/fct_optirayon.m
@@ -27,7 +27,7 @@ if CP2>0
     end
 
 else
-    x=1:0.0001:8;
+    x=1:0.00005:10;
     t=real(2*(CP2/CP1)*expint((log(x.^2)))-2*(CP2/CP1)*(1./(x.^2.*log(x)))+CP3);
     rf=-2*CP2./(x.*log(x));
     b=1;

--- a/ResolutionModeles.m
+++ b/ResolutionModeles.m
@@ -10,7 +10,7 @@ warning off
 %% CHOIX DU REPERTOIRE/BASE DE TRAVAIL ET CHARGEMENT DES DONNEES
 
 addpath('./Functions') % Répertoire où sont stockées les fonctions MATLAB
-RepBase = uigetdir('C:\Users\noe.monnier\Documents\Post_Proc'); % Répertoire où sont stockées les fichiers du tir
+RepBase = uigetdir('C:\Users\noe.monnier\Documents\NO\Experimental Database\'); % Répertoire où sont stockées les fichiers du tir
 OriginalRepBase = RepBase; % Copie du chemin du répertoire de travail
 
 imagesplit = false; % true si le Schlieren est split
@@ -54,7 +54,7 @@ for LeftRight=2:2 % Images à traiter : 1:1 (gauche) OU 1:2 (gauche et droite) O
     answer = inputdlg(prompt,dlg_title,num_lines,def);
     rbas = str2double(answer{1}); % Coupure basse
     rhaut = str2double(answer{2}); % Coupure haute
-    rmid = rhaut - rbas; % Rayon médian de coupure
+    rmid = (rhaut - rbas)/2 + rbas; % Rayon médian de coupure
 
     close all
     
@@ -137,7 +137,7 @@ for LeftRight=2:2 % Images à traiter : 1:1 (gauche) OU 1:2 (gauche et droite) O
         if Lb_2>0
             x = 1/exp(1):0.0001:1;
         else
-            x = 1:0.0001:4;
+            x = 1:0.00005:10;
         end
         % Calcul des vecteurs temps et rayon à partir du modèle Non Linéaire et des paramètres optimisés
         rf_recalc(:,l) = -2*Lb_2./(x.*log(x));


### PR DESCRIPTION
Buoyancy computation has been added to radii_Schlieren.m : 

- Roundness and shape ratio are now computed to track the evolution of the flame shape through propagation
- Centroïd displacement is now tracked to see if flame is affected by buoyancy
- Froude number is now computed to quantify the intensity of buoyancy on the flame propagation

The range of computation for negative Markstein length in Resolution_Modeles.m has been increses to take account of strongly negative Markstein length encountered during processing of experimental data  
